### PR TITLE
Small bug fixes and improvements

### DIFF
--- a/neware_reader/nda_version_8_0_beta.py
+++ b/neware_reader/nda_version_8_0_beta.py
@@ -31,6 +31,8 @@ def get_step_name(s):
         return 'CP_Chg'
     elif s==10:#WHAT IS 11-19??
         return 'CR_Dchg'
+    elif s==19:
+        return 'CV_Dchg'
     elif s == 20:
         return "CCCV_Dchg"
     else:
@@ -90,7 +92,7 @@ def multiplier(rng_cur):
     return factor
 
 
-# Return a dict containing the relevant data.  all nice and pretty like.
+# Return a dict containing the relevant data. all nice and pretty like.
 def new_byte_stream(byte_stream, small=False):
     curr_dict = {}
 
@@ -141,7 +143,7 @@ def new_byte_stream(byte_stream, small=False):
     curr_dict['voltage_V'] = vol / 10000
 
     # Current mA
-    cur = int.from_bytes(byte_stream[25:27], byteorder='little', signed=True)  # 7  current
+    cur = int.from_bytes(byte_stream[25:28], byteorder='little', signed=True)  # 7  current
     # 26:29 for BTS8.0 with no current change
     curr_dict['current_mA'] = cur/curr_multiplier
 
@@ -184,7 +186,7 @@ def new_byte_stream(byte_stream, small=False):
     curr_dict['timestamp'] = f'{year}-{month}-{day} {hour}:{minute}:{second}'
 
     # 78-86 Not sure. Extra space?
-    column_5 = int.from_bytes(byte_stream[77:78], byteorder='little', signed=True)  # 11
+    column_5 = int.from_bytes(byte_stream[77:80], byteorder='little', signed=True)  # 11
     curr_dict['column_5'] = column_5
 
     # print(curr_dict)

--- a/neware_reader/neware.py
+++ b/neware_reader/neware.py
@@ -14,15 +14,17 @@ def read_nda(inpath, testcols=False, split=False, small=False, beta=False):
     with open(inpath, 'rb') as f:
         data = f.read()
 
-    if data[112:115] == b'BTS':
+    find_v8_loc = data.find(b'BTS Client 8.') # This will need refining if there are big changes between 8.0 and 8.1
+
+    if find_v8_loc==-1: # i.e. if 'BTS Client 8.' isn't in the file
         outdata = old_nda.old_nda(inpath, testcols=testcols, split=split, small=small)
-    elif data[2693:2706]==b'BTS Client 8.':
+    elif data[find_v8_loc:find_v8_loc+13]==b'BTS Client 8.':
         if beta==True:
             outdata = nda_version_8_0_beta.nda_version_8_0(inpath, testcols=testcols, split=split, small=small)
         else:
             outdata = nda_version_8_0.nda_version_8_0(inpath, testcols=testcols, split=split, small=small)
     else:
-        outdata = new_nda.new_nda(inpath, testcols=testcols, split=split, small=small)
+        outdata = new_nda.new_nda(inpath, testcols=testcols, split=split, small=small) # Is this deprecated?
 
     return outdata
 


### PR DESCRIPTION
1. Fixed an issue where `data[2693:2706]==b'BTS Client 8.'` evaluates to False due to a change in header size
2. Added `'CV_Dchg'` to `step_name`
3. Increased the width of the `curr` byte length by 1. This was giving incorrect output for certain current ranges. This had not been noticed earlier because the extra byte was always `b'\x00'`.